### PR TITLE
Refactored code to remove post and pre transforms in the plugins and …

### DIFF
--- a/canada.yaml
+++ b/canada.yaml
@@ -6,3 +6,5 @@
 'census_input_files':
   'profile_data_csv': '/mnt/c/Users/STB60/Programs/Canada_BSTs/Data/2011-2016/Profile/98-401-X2016043_English_CSV_data.csv'
   'pums_h_csv':  '/mnt/c/Users/STB60/Programs/Canada_BSTs/Data/2011-2016/PUMS/pumf-98M0002-E-2016-hierarchical_F1.csv'
+'output_log_file': 'canada.out.txt'
+'output_data_log_file': 'canada_data_out.txt'

--- a/census_converters/hookimpl.py
+++ b/census_converters/hookimpl.py
@@ -22,20 +22,6 @@ class CensusConverterSpec:
         return
 
     @hookimpl
-    def pre_transform_clean_data(cens_conv_inst):
-        """
-        pre_transform_clean_data implmentation spec
-        """
-        return
-
-    @hookimpl
-    def post_transform_clean_data(cens_conv_inst):
-        """
-        post_transform_clean_data implementation spec
-        """
-        return
-
-    @hookimpl
     def transform(cens_conv_inst):
         """
         transform implementation spec

--- a/census_converters/hookspec.py
+++ b/census_converters/hookspec.py
@@ -22,29 +22,6 @@ class CensusConverterSpec:
         return
 
     @hookspec
-    def pre_transform_clean_data(cens_conv_inst):
-        """
-        pre_transform_clean_data:
-
-        Required function that does any cleaning of the data that needs to be done
-        prior to the transformation step.
-
-        This is templated with a keyword that is requered to be
-        self when passed in through the class
-        """
-        return
-
-    @hookspec
-    def post_transform_clean_data(cens_conv_inst):
-        """
-        This function performs post transformation cleaning on the data.
-
-        This is templated with a keyword that is requered to be
-        self when passed in through the class
-        """
-        return
-
-    @hookspec
     def transform(cens_conv_inst):
         """
         transform

--- a/input.py
+++ b/input.py
@@ -61,6 +61,10 @@ class InputParams:
         pp_print = pprint.PrettyPrinter(indent=4)
         return pp_print.pformat(self.input_params)
 
+    def __getitem__(self,key):
+        return self.input_params[key]
+
+
 
 """
 For Testing

--- a/input_schema.py
+++ b/input_schema.py
@@ -16,7 +16,9 @@ _schema = Schema({
     'census_input_files': And(dict,
                               {str: lambda x: os.path.exists(x)},
                               error="Invald Census Input Files"),
-    'census_fitting_vars': And([str])
+    'census_fitting_vars': And([str]),
+    'output_log_file': And(str),
+    'output_data_log_file': And(str)
     })
 
 """

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,98 @@
+"""
+logger module
+This module provides several levels of logging
+throughout the runs of Syntheco
+"""
+
+import logging
+import os
+
+
+def setup_logger(log_file='syntheco_log.txt',
+                 data_log_file='synthco_data.txt',
+                 log_level='INFO'):
+    """
+    setup_logger
+    initiallizes the logger
+
+    Arguments:
+        log_file      - Filename for the general logging file
+        data_log_file - Filename for the data logging file
+        log_level     - Default logging level for output
+                        can be ["INFO","DEBUG","WARN","ERROR","CRIT"]
+
+    Returns
+        Nothing
+    """
+
+    logger = logging.getLogger("syntheco_logger")
+    logger.setLevel(log_level)
+
+    file_handler = logging.FileHandler(log_file)
+    formatter = logging.Formatter('%(asctime)s: %(levelname)s: %(name)s : %(message)s')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    data_logger = logging.getLogger("syntheco_data_logger")
+    data_logger.setLevel("INFO")
+    data_file_handler = logging.FileHandler(data_log_file)
+    data_formatter = logging.Formatter('%(asctime)s: %(message)s')
+    data_file_handler.setFormatter(data_formatter)
+    data_logger.addHandler(data_file_handler)
+
+
+def log(level="INFO", msg=None):
+    """
+    log
+
+    Helper function that handles logging to the general
+    syntheco output file
+
+    Arguments:
+        level - The logging level you would like to use
+                can be ["INFO","DEBUG","WARN","ERROR","CRIT"]
+        msg   - The message to be logged.
+
+    Returns:
+       Nothing, output is logged to files
+    """
+
+    logger = logging.getLogger("syntheco_logger")
+    if msg is None:
+        logger.error("Logging made without message")
+        return
+    if level == "INFO":
+        logger.info(msg)
+    elif level == "DEBUG":
+        logger.debug(msg)
+    elif level == "WARN":
+        logger.warning(msg)
+    elif level == "ERROR":
+        logger.error(msg)
+    elif level == "CRIT":
+        logger.critical(msg)
+    else:
+        logger.error("Trying to log {} with an unknown level".format(msg))
+    return
+
+
+def data_log(msg=None):
+    """
+    data_log
+
+    Helper function that handles logging to the data
+    syntheco output file
+
+    Arguments:
+        msg   - The message to be logged.
+
+    Returns:
+       Nothing, output is logged to files
+    """
+    logger = logging.getLogger('syntheco_data_logger')
+
+    if msg is None:
+        logger.error("Logging made without message")
+        return
+
+    logger.info(msg)

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from input import InputParams
 from global_tables import GlobalTables
 from pums_data_tables import PUMSDataTables
 from summary_data_tables import SummaryDataTables
+from logger import setup_logger, log, data_log
 
 
 def main():
@@ -32,26 +33,48 @@ def main():
     args = parser.parse_args()
 
     ip = InputParams(args.input_file)
-    print("input = {}".format(ip.input_params))
-    census_conv = ip.input_params['census_converter']
 
+    log_level = "INFO"
+    if args.debug:
+        log_level = "DEBUG"
+
+    setup_logger(ip['output_log_file'], ip['output_data_log_file'], log_level)
+
+    log("INFO", "----------------------------------------------------------------------")
+    log("INFO", " Beginning SynthEco Run")
+    log("INFO", "----------------------------------------------------------------------")
+    log("INFO", "Input File = {}".format(args.input_file))
+    log("INFO", "Input Params = {}".format(ip))
+
+    data_log("----------------------------------------------------------------------")
+    data_log(" Beginning SynthEco Run")
+    data_log("----------------------------------------------------------------------")
+
+    census_conv = ip['census_converter']
+
+    log("INFO", "Setting Up Global Converters")
     glob_table_conv = CensusConverter(ip, census_conv, "global")
-    global_tables = GlobalTables(geo_unit_=ip.input_params['census_high_res_geo_unit'],
+    log("INFO", "Creating Global Tables")
+    global_tables = GlobalTables(geo_unit_=ip['census_high_res_geo_unit'],
                                  converter_=glob_table_conv)
-    print("Global Tables Created")
+    log("INFO", "Global Tables Created")
+
+    log("INFO", "Setting up Census Converters")
     pums_table_conv = CensusConverter(ip, census_conv, "pums")
     summary_table_conv = CensusConverter(ip, census_conv, "summary",
                                          _global_tables=global_tables)
-    summary_tables = SummaryDataTables(summary_variables_=ip.input_params['census_fitting_vars'],
-                                       geo_unit_=ip.input_params['census_high_res_geo_unit'],
+    log("INFO", "Creating Census Data Tables")
+    summary_tables = SummaryDataTables(summary_variables_=ip['census_fitting_vars'],
+                                       geo_unit_=ip['census_high_res_geo_unit'],
                                        converter_=summary_table_conv)
 
-    pums_heir_tables = PUMSDataTables(geo_unit_=ip.input_params['census_low_res_geo_unit'],
+    pums_heir_tables = PUMSDataTables(geo_unit_=ip['census_low_res_geo_unit'],
                                       converter_=pums_table_conv)
+    log("INFO", "Done Setting Up Tables")
 
-    print(f"{pums_heir_tables}")
-    print(f"{global_tables}")
-    print(f"{summary_tables}")
+    data_log(f"{pums_heir_tables}")
+    data_log(f"{global_tables}")
+    data_log(f"{summary_tables}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I removed the plugin functions pre_transform_data_clean nd post_transform_data_clean, so all of the logic for transforming the data is now in transform.

Also, I added a logging capability. To use it, basically just include `import logger` in the module. To log general comments, the helper function `log` is available, and for data cleaning and manipulation logging, there is `data_log`. These will go to two separate files that are specified in the yaml as logging files. Currently, the log files do not reset.